### PR TITLE
Fix problem with tables not being removed

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,8 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: "3.6.1"}
-          - {os: macOS-latest,   r: "3.6.1"}
+          - {os: windows-latest, r: "4.0.5"}
+          - {os: macOS-latest,   r: "4.0.5"}
+          - {os: ubuntu-20.04,   r: "4.0.5"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/R/contingencytables.R
+++ b/R/contingencytables.R
@@ -208,7 +208,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 
   for (i in 1:nrow(analyses)) {
     analysis <- analyses[i,]
-    analysisContainer <- jaspResults[[paste0("container",i)]]
+    analysisContainer <- jaspResults[[paste0("container", i)]]
     if (!is.null(analysisContainer[["crossTabLogOdds"]]))
       next
 

--- a/R/contingencytables.R
+++ b/R/contingencytables.R
@@ -91,17 +91,25 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
   return(analyses)
 }
 
+.crossTabCreateContainerName <- function(analysis, prefix = "container") {
+  if (nrow(analysis) != 1)
+    stop("Attempting to create container name for multiple analyses. Each analysis has its own container.")
+
+  return(paste(prefix, analysis$rows, analysis$columns, sep = "_"))
+}
+
 # Container
 .crossTabContainer <- function(jaspResults, options, analyses, ready) {
   for (i in 1:nrow(analyses)){
     analysis <- analyses[i,]
-    if (is.null(jaspResults[[paste0("container", i)]])) {
+    containerName <- .crossTabCreateContainerName(analysis)
+    if (is.null(jaspResults[[containerName]])) {
       container <- createJaspContainer()
       container$dependOn(options              = c("layers", "counts"),
                          optionContainsValue  = list(rows     = analysis$rows,
                                                      columns  = analysis$columns))
       container$position <- 1
-      jaspResults[[paste0("container", i)]] <- container
+      jaspResults[[containerName]] <- container
     }
   }
 }
@@ -110,7 +118,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 .crossTabMain <- function(jaspResults, dataset, options, analyses, ready) {
   for (i in 1:nrow(analyses)){
     analysis <- analyses[i,]
-    analysisContainer <- jaspResults[[paste0("container", i)]]
+    analysisContainer <- jaspResults[[.crossTabCreateContainerName(analysis)]]
     if (!is.null(analysisContainer[["crossTabMain"]]))
       next
 
@@ -166,7 +174,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 
   for (i in 1:nrow(analyses)){
     analysis          <- analyses[i,]
-    analysisContainer <- jaspResults[[paste0("container", i)]]
+    analysisContainer <- jaspResults[[.crossTabCreateContainerName(analysis)]]
     if (!is.null(analysisContainer[["crossTabChisq"]]))
       next
 
@@ -208,7 +216,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 
   for (i in 1:nrow(analyses)) {
     analysis <- analyses[i,]
-    analysisContainer <- jaspResults[[paste0("container", i)]]
+    analysisContainer <- jaspResults[[.crossTabCreateContainerName(analysis)]]
     if (!is.null(analysisContainer[["crossTabLogOdds"]]))
       next
 
@@ -247,7 +255,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 
   for (i in 1:nrow(analyses)){
     analysis <- analyses[i,]
-    analysisContainer <- jaspResults[[paste0("container", i)]]
+    analysisContainer <- jaspResults[[.crossTabCreateContainerName(analysis)]]
     if (!is.null(analysisContainer[["crossTabNominal"]]))
       next
     # Create table
@@ -286,7 +294,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 
   for (i in 1:nrow(analyses)){
     analysis <- analyses[i,]
-    analysisContainer <- jaspResults[[paste0("container", i)]]
+    analysisContainer <- jaspResults[[.crossTabCreateContainerName(analysis)]]
     if (!is.null(analysisContainer[["crossTabGamma"]]))
       next
 
@@ -320,7 +328,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 
   for (i in 1:nrow(analyses)){
     analysis <- analyses[i,]
-    analysisContainer <- jaspResults[[paste0("container", i)]]
+    analysisContainer <- jaspResults[[.crossTabCreateContainerName(analysis)]]
     if (!is.null(analysisContainer[["crossTabKendallTau"]]))
       next
 

--- a/R/contingencytablesbayesian.R
+++ b/R/contingencytablesbayesian.R
@@ -18,10 +18,10 @@
 ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...) {
   dataset <- .crossTabReadData(dataset, options)
   ready <- !(length(options$rows) == 0 || length(options$columns) == 0)
-  
+
   if(ready)
     .crossTabCheckErrors(dataset, options)
-  
+
   # Compute the combinations of rows, columns, layers
   analyses <- .crossTabComputeAnalyses(dataset, options, ready)
   # Tables container - groups per analysis
@@ -31,10 +31,10 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
   .contTabBasBF(      jaspResults, options, analyses, ready)
   .contTabBasLogOdds( jaspResults, options, analyses, ready)
   .contTabBasCramersV(jaspResults, options, analyses, ready)
-  
+
   # Plots
   .contTabBasLogOddsPlot(jaspResults, options, analyses, ready)
-  
+
   return()
 }
 
@@ -43,30 +43,30 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
   for (i in 1:nrow(analyses)){
     analysis <- analyses[i,]
     analysisContainer <- jaspResults[[paste0("container", i)]]
-    if (!is.null(analysisContainer[["contTabBasBF"]])) 
+    if (!is.null(analysisContainer[["contTabBasBF"]]))
       next
-    
+
     # Create table
     contTabBasBF <- createJaspTable(title = gettext("Bayesian Contingency Tables Tests"))
     dependList <- c("samplingModel", "hypothesis", "bayesFactorType", "priorConcentration", "setSeed", "seed")
     contTabBasBF$dependOn(dependList)
     contTabBasBF$showSpecifiedColumnsOnly <- TRUE
     contTabBasBF$position <- 2
-    
+
     # Add columns to table
     .crossTabLayersColumns(contTabBasBF, analysis)
     contTabBasBF$addColumnInfo(name = "type[BF]",  title = "",               type = "string")
     contTabBasBF$addColumnInfo(name = "value[BF]", title = gettext("Value"), type = "number")
     contTabBasBF$addColumnInfo(name = "type[N]",   title = "",               type = "string")
     contTabBasBF$addColumnInfo(name = "value[N]",  title = gettext("Value"), type = "integer")
-    
+
     analysisContainer[["contTabBasBF"]] <- contTabBasBF
     analysis <- as.list(analysis)
     # Compute/get groupList
     groupList <- .crossTabComputeGroups(dataset, options, analysisContainer, analysis, ready)
     # Compute/get bfList
     bfList <- .contTabBasComputeBfList(analysisContainer, options, groupList, ready)
-    
+
     res <- try(.contTabBasBFRows(analysisContainer, analysis$rows, groupList, bfList, options, ready))
     .contTabBasSetErrorOrFill(res, contTabBasBF)
   }
@@ -78,34 +78,34 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
   for (i in 1:nrow(analyses)){
     analysis <- analyses[i,]
     analysisContainer <- jaspResults[[paste0("container", i)]]
-    if (!is.null(analysisContainer[["contTabBasLogOdds"]])) 
+    if (!is.null(analysisContainer[["contTabBasLogOdds"]]))
       next
-    
+
     # Create table
     contTabBasLogOdds <- createJaspTable(title = gettext("Log Odds Ratio"))
     dependList <- c("oddsRatio", "oddsRatioCredibleIntervalInterval", "hypothesis", "samplingModel", "priorConcentration", "setSeed", "seed")
     contTabBasLogOdds$dependOn(dependList)
     contTabBasLogOdds$showSpecifiedColumnsOnly <- TRUE
     contTabBasLogOdds$position <- 3
-    
+
     ci.label <- gettextf("%.0f%% Credible Interval", 100*options$oddsRatioCredibleIntervalInterval)
-    
+
     # Add columns to table
     .crossTabLayersColumns(contTabBasLogOdds, analysis)
     #contTabBasLogOdds$addColumnInfo(name = "type[oddsRatio]",  title = "", type = "string")
     contTabBasLogOdds$addColumnInfo(name = "value[oddsRatio]", title = gettext("Log Odds Ratio"), type = "number")
     contTabBasLogOdds$addColumnInfo(name = "low[oddsRatio]",   title = gettext("Lower"),          type = "number", overtitle = ci.label, format = "dp:3")
     contTabBasLogOdds$addColumnInfo(name = "up[oddsRatio]",    title = gettext("Upper"),          type = "number", overtitle = ci.label, format = "dp:3")
-    
+
     analysisContainer[["contTabBasLogOdds"]] <- contTabBasLogOdds
     analysis <- as.list(analysis)
     # Compute/get groupList
     groupList <- .crossTabComputeGroups(dataset, options, analysisContainer, analysis, ready)
     # Compute/get bfList
     bfList <- .contTabBasComputeBfList(analysisContainer, options, groupList, ready)
-    
+
     res <- try(.contTabBasOddsRatioRows(analysisContainer, analysis$rows, groupList, bfList, options, ready))
-   
+
     .contTabBasSetErrorOrFill(res, contTabBasLogOdds)
   }
 }
@@ -117,14 +117,14 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
   for (i in 1:nrow(analyses)){
     analysis          <- analyses[i,]
     analysisContainer <- jaspResults[[paste0("container", i)]]
-    if (!is.null(analysisContainer[["contTabBasCramersV"]])) 
+    if (!is.null(analysisContainer[["contTabBasCramersV"]]))
       next
 
     # Create table
     contTabBasCramersV <- createJaspTable(title = gettext("Cramer's V"), dependencies="effectSize")
     contTabBasCramersV$showSpecifiedColumnsOnly <- TRUE
     contTabBasCramersV$position <- 4
-    
+
     ci <- gettextf("%.0f%% Credible Interval", 100 * options$effectSizeCredibleIntervalInterval)
 
     # Add columns to table
@@ -139,7 +139,7 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
     groupList <- .crossTabComputeGroups(dataset, options, analysisContainer, analysis, ready)
     # Compute/get bfList
     bfList <- .contTabBasComputeBfList(analysisContainer, options, groupList, ready)
-    
+
     res <- try(.contTabBasCramersVRows(analysisContainer, analysis$rows, groupList, bfList, options, ready))
     .contTabBasSetErrorOrFill(res, contTabBasCramersV)
   }
@@ -157,12 +157,12 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
   oddsRatioPlotContainer$position <- 2
   .contTablesBayesianCitations(oddsRatioPlotContainer)
   for (i in 1:nrow(analyses)){
-    if (!is.null(oddsRatioPlotContainer[[paste0("plots", i)]])) 
+    if (!is.null(oddsRatioPlotContainer[[paste0("plots", i)]]))
       next
     analysisContainer <- jaspResults[[paste0("container", i)]]
     # get groupList
     groupList <- analysisContainer[["groupList"]]$object
-    
+
     group.matrices <- groupList$group.matrices
     groups <- groupList$groups
     for (g in 1:length(group.matrices)) {
@@ -171,12 +171,12 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
         group <- groups[[g]]
       else
         group <- NULL
-      
+
       if(!identical(dim(group.matrices[[1]]), as.integer(c(2,2))))
         return()
-      
+
       group[group == ""] <- gettext("Total")
-      
+
       if (length(group) == 0)
         oddsRatioSubContainer <- createJaspContainer()
       else if (length(group) > 0) {
@@ -188,7 +188,7 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
       }
       analysis <- analyses[i,]
       title    <- ""
-      
+
       if(length(options$rows) > 0 || length(options$columns) > 0)
         title <- paste0(analysis$rows, " - ", analysis$columns)
       logOddsPlot <- createJaspPlot(title = title, width = 530, height = 400)
@@ -196,7 +196,7 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
       logOddsPlot$dependOn(optionContainsValue = list(rows = analysis$rows, columns = analysis$columns))
       oddsRatioSubContainer[["plot"]] <- logOddsPlot
       oddsRatioPlotContainer[[paste0("plots", i, "sub", g)]] <- oddsRatioSubContainer
-      
+
       if(ready){
         analysisSamples.g <- analysisContainer[["logOddsSamples"]][[g]]
         # Get bfList
@@ -217,7 +217,7 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
 
 .contTabBasLogOddsPlotFill <- function(analysisContainer, options, analysisSamples.g,
                                        counts.matrix, bf.results.g, group) {
-  
+
   if (options$samplingModel == "hypergeometric")
     stop(gettext("Odds ratio for this model not yet implemented"))
   else {
@@ -245,7 +245,7 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
   result  <- try(.contTabBasOddsRatioSamples(analysisSamples.g, bf.results.g, options))
   samples <- result$log.odds.ratio.samples
   xlim    <- vector("numeric", 2)
-  
+
   switch(oneSided,
     notABoolean = {
       xlim[1] <- quantile(samples, probs = 0.002)
@@ -275,20 +275,20 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
     p <- jaspGraphs::PlotPriorAndPosterior(dfLines = dfLines, xName = xName, BF = BF10, bfType = "BF10",
                                            CRI = ppCri, median = median, bfSubscripts = bfSubscripts,
                                            CRItxt = CRItxt, medianTxt = medianTxt)
-  else 
-    p <- jaspGraphs::PlotPriorAndPosterior(dfLines = dfLines, xName = xName, CRI = ppCri,  
+  else
+    p <- jaspGraphs::PlotPriorAndPosterior(dfLines = dfLines, xName = xName, CRI = ppCri,
                                            bfSubscripts = bfSubscripts, draqCRItxt = FALSE)
 
   p$subplots$mainGraph <- p$subplots$mainGraph+ggplot2::theme(legend.position = "none")
   return(p)
 }
 
-# Table functions 
+# Table functions
 .contTabBasSetErrorOrFill <- function(res, table) {
   if(isTryError(res))
     table$setError(.extractErrorMessage(res))
   else
-    for (level in 1:length(res)) 
+    for (level in 1:length(res))
       table$addRows(res[[level]])
 }
 
@@ -298,10 +298,10 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
   bfList <- list()
   grp.mat <- groupList$group.matrices
   if(!ready) return()
-  for(g in 1:length(grp.mat)) 
+  for(g in 1:length(grp.mat))
     bfList[[g]]   <- .contTabBasComputeBF(options, grp.mat[[g]], ready)
   analysisContainer[["bfList"]] <- createJaspState(bfList)
-  analysisContainer[["bfList"]]$dependOn(c("samplingModel", "priorConcentration", 
+  analysisContainer[["bfList"]]$dependOn(c("samplingModel", "priorConcentration",
                                            "hypothesis", "bayesFactorType", "setSeed", "seed"))
   return(bfList)
 }
@@ -333,10 +333,10 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
       sampleType  <- "hypergeom"
     }
   )
-  
+
   BF <- try({
-    BayesFactor::contingencyTableBF(counts.matrix, sampleType = sampleType, 
-                                    priorConcentration = options$priorConcentration, 
+    BayesFactor::contingencyTableBF(counts.matrix, sampleType = sampleType,
+                                    priorConcentration = options$priorConcentration,
                                     fixedMargin = fixedMargin) })
 
   bf1  <- exp(as.numeric(BF@bayesFactor$bf))
@@ -358,7 +358,7 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
 
       if(options$hypothesis == "groupOneGreater") prop.consistent <- 1 - mean(logOR < 0)
       else                                        prop.consistent <- mean(logOR < 0)
-    
+
     } else if(options$samplingModel %in% rowsOrCols) {
 
       theta <- as.data.frame(ch.result[,7:10])
@@ -379,7 +379,7 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
       lbf1 <- lbf1 + log(prop.consistent) - log(0.5)
     }
   }
-  
+
   switch(options$hypothesis,
     groupOneGreater = { bfTitleUniquePart <- "\u208A" }, #On my system these code points seem to be rendered as B+0, B0+ etc. Probably wrong then?
     groupTwoGreater = { bfTitleUniquePart <- "\u208B" },
@@ -387,7 +387,7 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
 
   #I am not adding the following bfTitle's to the translation strings because there is not a lot to translate and it would be neigh incomprehensible if all those unicode chars were %s...
   switch(options$bayesFactorType,
-    BF10 = { 
+    BF10 = {
       bfTitle <- paste0("BF", bfTitleUniquePart, "\u2080")
       bfVal   <- bf1
     },
@@ -450,14 +450,14 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
 
 .contTablesBayesianCitations <- function(object) {
   citationList <- list(
-    "Morey, R. D., & Rouder, J. N. (2015). BayesFactor 
+    "Morey, R. D., & Rouder, J. N. (2015). BayesFactor
     (Version 0.9.11-3)[Computer software].",
-    "Jamil, T., Ly, A., Morey, R. D., Love, J., 
-    Marsman, M., & Wagenmakers, E.-J. (2017). 
-    Default Gunel and Dickey Bayes factors for contingency tables. 
+    "Jamil, T., Ly, A., Morey, R. D., Love, J.,
+    Marsman, M., & Wagenmakers, E.-J. (2017).
+    Default Gunel and Dickey Bayes factors for contingency tables.
     Behavior Research Methods, 49, 638-652.",
-    "Gunel, E., & Dickey, J. (1974). 
-    Bayes factors for independence in contingency tables. 
+    "Gunel, E., & Dickey, J. (1974).
+    Bayes factors for independence in contingency tables.
     Biometrika, 61, 545-557.")
 
   for(citation in citationList)
@@ -497,14 +497,14 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
   #median <- stats::median(samples)
   #lower  <- unname(stats::quantile(samples, p = alpha))
   #upper  <- unname(stats::quantile(samples, p = (1-alpha)))
-  samplesList <- list(log.odds.ratio.samples = samples, BF = BF, 
+  samplesList <- list(log.odds.ratio.samples = samples, BF = BF,
                       median = median, lower.ci = lower, upper.ci = upper)
   logOddsSamples    <- createJaspState(samplesList)
   analysisSamples.g <- logOddsSamples
   return(samplesList)
 }
 
-# Table Results 
+# Table Results
 .contTabBasBFRows <- function(analysisContainer, var.name, groupList, bf.results, options, ready) {
   bf.rows <- list()
   group.matrices <- groupList$group.matrices
@@ -512,24 +512,24 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
 
   for (g in 1:length(group.matrices)) {
     counts.matrix <- group.matrices[[g]]
-    
+
     if (!is.null(groups)) group <- groups[[g]]
     else                  group <- NULL
 
     row <- list()
     row[["type[BF]"]] <- paste(bf.results[[g]]$bfTitle, bf.results[[g]]$bfEndLab)
     row[["type[N]"]]  <- "N"
-    
+
     if (ready) {
       row[["value[BF]"]] <- bf.results[[g]]$bfVal
       row[["value[N]"]]  <- sum(counts.matrix)
-    } else 
+    } else
       row[["value[BF]"]] <- row[["value[N]"]]  <- "."
-    
+
     bf.rows[[length(bf.rows) + 1]] <- .crossTabLayerNames(row, group)
   }
 
-  .contTabBasBFFootnote(options, counts.matrix, analysisContainer, ready) 
+  .contTabBasBFFootnote(options, counts.matrix, analysisContainer, ready)
   return(bf.rows)
 }
 
@@ -540,10 +540,10 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
 
   for (g in 1:length(group.matrices)) {
     counts.matrix <- group.matrices[[g]]
-    
+
     if (!is.null(groups)) group <- groups[[g]]
     else                  group <- NULL
-    
+
     row                       <- .crossTabLayerNames(list(), group)
     row[["type[oddsRatio]"]]  <- gettext("Odds ratio")
     result                    <- list(median = ".", lower  = ".", upper  = ".")
@@ -567,7 +567,7 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
     row[["value[oddsRatio]"]] <- result$median
     row[["low[oddsRatio]"]]   <- result$lower
     row[["up[oddsRatio]"]]    <- result$upper
-    
+
     odds.ratio.rows[[length(odds.ratio.rows) + 1]] <- row
   }
   return(odds.ratio.rows)
@@ -580,17 +580,17 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
 
   for (g in 1:length(group.matrices)) {
     counts.matrix <- group.matrices[[g]]
-   
+
     if (!is.null(groups)) group <- groups[[g]]
     else                  group <- NULL
-    
+
     row                         <- .crossTabLayerNames(list(), group)
     row[["type[CramerV]"]]      <- gettext("Cramer's V")
 
     if ( options$samplingModel == "hypergeometric") {
       row[["value[CramerV]"]] <- NaN
       row[["low[CramerV]"]]   <- row[["up[CramerV]"]] <- ""
-      
+
       message <- gettext("Cramer's V for this model not yet implemented")
       analysisContainer[["contTabCramersV"]]$addFootnote(message)
 
@@ -605,7 +605,7 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
         N  <- sum(counts.matrix)
         yr <- rowSums(counts.matrix)
         yc <- colSums(counts.matrix)
-        
+
         if (options$samplingModel == "poisson") {
 
           lambda    <- as.data.frame(ch.result)
@@ -640,18 +640,18 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
           Phi.indepMulti <- sqrt(chi2/(N*(k-1)))
           Cramer         <- Phi.indepMulti
 
-        } else 
+        } else
           stop(("Invalid sampling model selected"))
-        
+
         CramersV.samples <- Cramer
         CramersV.median  <- stats::median(CramersV.samples)
         sig   <- options$effectSizeCredibleIntervalInterval
         alpha <- (1 - sig) / 2
         lower <- unname(stats::quantile(Cramer, p = alpha))
         upper <- unname(stats::quantile(Cramer, p = (1-alpha)))
-        
-        list(CramersV.samples = CramersV.samples, 
-             BF = BF, CVmedian = CramersV.median, 
+
+        list(CramersV.samples = CramersV.samples,
+             BF = BF, CVmedian = CramersV.median,
              CV.lower.ci = lower, CV.upper.ci = upper)
       })
     } else {
@@ -673,13 +673,13 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
   linesPosterior  <- numeric(size) # initializes everything to 0
 
   switch(oneSided,
-    notABoolean = { 
-      linesPosterior <- dnorm(logOR, mean, sd) 
+    notABoolean = {
+      linesPosterior <- dnorm(logOR, mean, sd)
     },
     right = {
       idx                 <- logOR >= 0 # the nonzero components
       linesPosterior[idx] <- dnorm(logOR, mean, sd) / pnorm(0, mean, sd, lower.tail = FALSE)
-      linesPosterior[1]   <- 0 # gives the sharp truncation line 
+      linesPosterior[1]   <- 0 # gives the sharp truncation line
     },
     left = {
       idx                  <- logOR <= 0 # the nonzero components
@@ -693,12 +693,12 @@ ContingencyTablesBayesian <- function(jaspResults, dataset = NULL, options, ...)
   return(dat)
 }
 
-#CRI and Median 
+#CRI and Median
 .crossTabCIPlusMedian <- function(credibleIntervalInterval = .95, mean, sd, hypothesis = "groupsNotEqual") {
-  
+
   lower <- (1 - credibleIntervalInterval) / 2
   upper <- 1 - lower
-  
+
   switch(hypothesis,
     groupsNotEqual={
       quantiles <- qnorm(c(lower, .5, upper), mean, sd)

--- a/tests/testthat/test-contingencytables.R
+++ b/tests/testthat/test-contingencytables.R
@@ -17,7 +17,7 @@ test_that("Main table results match", {
   options$percentagesColumn <- TRUE
   options$percentagesTotal <- TRUE
   results <- jaspTools::runAnalysis("ContingencyTables", "test.csv", options)
-  table   <- results[["results"]][["container1"]][["collection"]][["container1_crossTabMain"]][["data"]]
+  table   <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_crossTabMain"]][["data"]]
   jaspTools::expect_equal_tables(table,
       list(0.489296636085627, 320, 394.529977794227, 0.236861584011843, 0.392638036809816,
            0.710186513629842, 495, 420.470022205773, 0.36639526276832,
@@ -65,18 +65,15 @@ test_that("Multiple row and column variables give multiple main tables", {
   options$columns <- c("contBinom", "facFive")
   results <- jaspTools::runAnalysis("ContingencyTables", "test.csv", options)
 
-  pairs <- list(
-    c("facExperim", "contBinom"),
-    c("facExperim", "facFive"),
-    c("facGender", "contBinom"),
-    c("facGender", "facFive")
-  )
+  table1 <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_crossTabMain"]][["data"]]
+  table2 <- results[["results"]][["container_facExperim_facFive"]][["collection"]][["container_facExperim_facFive_crossTabMain"]][["data"]]
+  table3 <- results[["results"]][["container_facGender_contBinom"]][["collection"]][["container_facGender_contBinom_crossTabMain"]][["data"]]
+  table4 <- results[["results"]][["container_facGender_facFive"]][["collection"]][["container_facGender_facFive_crossTabMain"]][["data"]]
 
-  for (i in 1:4) {
-    rows <- results[["results"]][[paste0("container", i)]][["collection"]][[paste0("container", i, "_crossTabMain")]][["schema"]][["fields"]][[1]][["name"]]
-    cols <- results[["results"]][[paste0("container", i)]][["collection"]][[paste0("container", i, "_crossTabMain")]][["schema"]][["fields"]][[2]][["overTitle"]]
-    expect_identical(c(rows, cols), pairs[[i]], label=paste("Table", i))
-  }
+  expect_is(table1, "list", label = "facExperim-contBinom table")
+  expect_is(table2, "list", label = "facExperim-Facfive table")
+  expect_is(table3, "list", label = "facGender-contBinom table")
+  expect_is(table4, "list", label = "facGender-facFive table")
 })
 
 test_that("Chi-Squared test table results match", {
@@ -89,7 +86,7 @@ test_that("Chi-Squared test table results match", {
   options$likelihoodRatio <- TRUE
   options$VovkSellkeMPR <- TRUE
   results <- jaspTools::runAnalysis("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabChisq"]][["data"]]
+  table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_crossTabChisq"]][["data"]]
   jaspTools::expect_equal_tables(table,
     list("N", "", "", "", 2550,
          "<unicode>", 82.0397085317219, 1, 1.33379878452991e-19, 63462127883801120,
@@ -105,7 +102,7 @@ test_that("Nominal table results match", {
   options$contingencyCoefficient <- TRUE
   options$phiAndCramersV <- TRUE
   results <- jaspTools::runAnalysis("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabNominal"]][["data"]]
+  table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_crossTabNominal"]][["data"]]
   jaspTools::expect_equal_tables(table,
     list("Contingency coefficient", 0.0807792391722019, "Phi-coefficient",
          0.0810440898473108, "Cramer's V ", 0.0810440898473108)
@@ -119,7 +116,7 @@ test_that("Log Odds Ratio table results match", {
   options$oddsRatio <- TRUE
   options$oddsRatioConfidenceIntervalInterval <- 0.90
   results <- jaspTools::runAnalysis("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabLogOdds"]][["data"]]
+  table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_crossTabLogOdds"]][["data"]]
   jaspTools::expect_equal_tables(table,
     list("Odds ratio", -0.329205575243527, -0.998167649205055, 0.339756498718001,"",
          "Fisher's exact test ", -0.325882968750928, -1.07370478788709,
@@ -133,7 +130,7 @@ test_that("Ordinal Gamma table results match", {
   options$columns <- "contBinom"
   options$gamma <- TRUE
   results <- jaspTools::runAnalysis("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabGamma"]][["data"]]
+  table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_crossTabGamma"]][["data"]]
   jaspTools::expect_equal_tables(table,
     list(-0.163132137030995, 0.197938461395245, -0.551084392520947, 0.224820118458957)
   )
@@ -146,7 +143,7 @@ test_that("Kendall's Tau table results match", {
   options$kendallsTauB <- TRUE
   options$VovkSellkeMPR <- TRUE
   results <- jaspTools::runAnalysis("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabKendallTau"]][["data"]]
+  table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_crossTabKendallTau"]][["data"]]
   jaspTools::expect_equal_tables(table,
     list(-0.0810440898473108, 0.420024632711394, 1, -0.806378512498144)
   )
@@ -167,7 +164,7 @@ test_that("Goodman-Kruskal lambda and Cramer's V results match", {
   options$phiAndCramersV <- TRUE
 
   results <- jaspTools::runAnalysis("ContingencyTables", df, options)
-  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabNominal"]][["data"]][[1]]
+  table <- results[["results"]][["container_var1_var2"]][["collection"]][["container_var1_var2_crossTabNominal"]][["data"]][[1]]
 
   # reported 0.3636
   testthat::expect_equal(table[["value[LambdaC]"]], 0.363636363636364)
@@ -196,10 +193,10 @@ options$rows <- "V1"
 set.seed(1)
 # data is a random sample from https://github.com/jasp-stats/jasp-issues/issues/811
 dataset <- structure(list(V1 = c(1L, 2L, 1L, 2L, 1L, 0L, 2L, 0L, 0L, 1L), V2 = c(0L, 0L, 1L, 0L, 0L, 1L, 0L, 1L, 1L, 0L)), row.names = c(NA, -10L), class = "data.frame")
-results <- runAnalysis("ContingencyTables", dataset, options)
+results <- jaspTools::runAnalysis("ContingencyTables", dataset, options)
 
 test_that("Phi coefficient is only available for 2 by 2 contingency tables", {
-  tb <- results[["results"]][["container1"]][["collection"]][["container1_crossTabNominal"]]
+  tb <- results[["results"]][["container_V1_V2"]][["collection"]][["container_V1_V2_crossTabNominal"]]
   table <- tb[["data"]]
   jaspTools::expect_equal_tables(
     test  = table,

--- a/tests/testthat/test-contingencytablesbayesian.R
+++ b/tests/testthat/test-contingencytablesbayesian.R
@@ -20,9 +20,9 @@ test_that("Main table results match", {
   table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabMain"]][["data"]]
   jaspTools::expect_equal_tables(table,
     list("TRUE", 320, 495, "control", "f", 815, 334, 202, "experimental",
-         "f", 536, "TRUE", 654, 697, "Total", "f", 1351, 
+         "f", 536, "TRUE", 654, 697, "Total", "f", 1351,
          "TRUE", 253, 182, "control", "m", 435, 494, 270, "experimental",
-         "m", 764, "TRUE", 747, 452, "Total", "m", 1199, 
+         "m", 764, "TRUE", 747, 452, "Total", "m", 1199,
          "TRUE", 573, 677, "control", "Total", 1250, 828, 472,
          "experimental", "Total", 1300, "TRUE", 1401, 1149,
          "Total", "Total", 2550)
@@ -79,30 +79,30 @@ test_that("Bayesian Contingency Tables Tests table results match - different hyp
   options$rows <- "facExperim"
   options$columns <- "contBinom"
   options$priorConcentration <- 1.5
-  
+
   samplingModels <- c("poisson", "jointMultinomial", "independentMultinomialRowsFixed",
                       "independentMultinomialColumnsFixed")
   hypotheses <- c("groupsNotEqual", "groupOneGreater", "groupTwoGreater")
-  
+
   refTables <- list(
     poisson = list(
       groupsNotEqual  = list("BF<unicode><unicode> Poisson", "N", 100, 0.523118843924781),
-      groupOneGreater = list("BF<unicode><unicode> Poisson", "N", 100, 0.224941102887656),             
+      groupOneGreater = list("BF<unicode><unicode> Poisson", "N", 100, 0.224941102887656),
       groupTwoGreater = list("BF<unicode><unicode> Poisson", "N", 100, 0.818576366973497)),
     jointMultinomial = list(
       groupsNotEqual  = list("BF<unicode><unicode> joint multinomial", "N", 100, 0.440084106793853),
-      groupOneGreater = list("BF<unicode><unicode> joint multinomial", "N", 100, 0.181490685641785),             
+      groupOneGreater = list("BF<unicode><unicode> joint multinomial", "N", 100, 0.181490685641785),
       groupTwoGreater = list("BF<unicode><unicode> joint multinomial", "N", 100, 0.683978718779006)),
     independentMultinomialRowsFixed = list(
       groupsNotEqual  = list("BF<unicode><unicode> independent multinomial", "N", 100, 0.35545254779504),
-      groupOneGreater = list("BF<unicode><unicode> independent multinomial", "N", 100, 0.149361160583476),             
+      groupOneGreater = list("BF<unicode><unicode> independent multinomial", "N", 100, 0.149361160583476),
       groupTwoGreater = list("BF<unicode><unicode> independent multinomial", "N", 100, 0.560761939401455)),
     independentMultinomialColumnsFixed = list(
       groupsNotEqual  = list("BF<unicode><unicode> independent multinomial", "N", 100, 0.364069579256729),
-      groupOneGreater = list("BF<unicode><unicode> independent multinomial", "N", 100, 0.153564548530488),             
+      groupOneGreater = list("BF<unicode><unicode> independent multinomial", "N", 100, 0.153564548530488),
       groupTwoGreater = list("BF<unicode><unicode> independent multinomial", "N", 100, 0.571734867264767))
   )
-  
+
   for (samplingModel in samplingModels) {
     options$samplingModel <- samplingModel
     for(hypothesis in hypotheses) {

--- a/tests/testthat/test-contingencytablesbayesian.R
+++ b/tests/testthat/test-contingencytablesbayesian.R
@@ -17,7 +17,7 @@ test_that("Main table results match", {
     variables = "facGender")
   )
   results <- jaspTools::runAnalysis("ContingencyTablesBayesian", "test.csv", options)
-  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabMain"]][["data"]]
+  table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_crossTabMain"]][["data"]]
   jaspTools::expect_equal_tables(table,
     list("TRUE", 320, 495, "control", "f", 815, 334, 202, "experimental",
          "f", 536, "TRUE", 654, 697, "Total", "f", 1351,
@@ -35,18 +35,15 @@ test_that("Multiple row and column variables give multiple main tables", {
   options$columns <- c("contBinom", "facFive")
   results <- jaspTools::runAnalysis("ContingencyTablesBayesian", "test.csv", options)
 
-  pairs <- list(
-    c("facExperim", "contBinom"),
-    c("facExperim", "facFive"),
-    c("facGender", "contBinom"),
-    c("facGender", "facFive")
-  )
+  table1 <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_crossTabMain"]][["data"]]
+  table2 <- results[["results"]][["container_facExperim_facFive"]][["collection"]][["container_facExperim_facFive_crossTabMain"]][["data"]]
+  table3 <- results[["results"]][["container_facGender_contBinom"]][["collection"]][["container_facGender_contBinom_crossTabMain"]][["data"]]
+  table4 <- results[["results"]][["container_facGender_facFive"]][["collection"]][["container_facGender_facFive_crossTabMain"]][["data"]]
 
-  for (i in 1:4) {
-    rows <- results[["results"]][[paste0("container", i)]][["collection"]][[paste0("container", i, "_crossTabMain")]][["schema"]][["fields"]][[1]][["name"]]
-    cols <- results[["results"]][[paste0("container", i)]][["collection"]][[paste0("container", i, "_crossTabMain")]][["schema"]][["fields"]][[2]][["overTitle"]]
-    expect_identical(c(rows, cols), pairs[[i]], label=paste("Table", i))
-  }
+  expect_is(table1, "list", label = "facExperim-contBinom table")
+  expect_is(table2, "list", label = "facExperim-Facfive table")
+  expect_is(table3, "list", label = "facGender-contBinom table")
+  expect_is(table4, "list", label = "facGender-facFive table")
 })
 
 test_that("Bayesian Contingency Tables Tests table results match", {
@@ -68,7 +65,7 @@ test_that("Bayesian Contingency Tables Tests table results match", {
   for (samplingModel in samplingModels) {
     options$samplingModel <- samplingModel
     results <- jaspTools::runAnalysis("ContingencyTablesBayesian", "test.csv", options)
-    table <- results[["results"]][["container1"]][["collection"]][["container1_contTabBasBF"]][["data"]]
+    table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_contTabBasBF"]][["data"]]
     jaspTools::expect_equal_tables(table, refTables[[samplingModel]], label=paste("Sampling model", samplingModel))
   }
 })
@@ -108,7 +105,7 @@ test_that("Bayesian Contingency Tables Tests table results match - different hyp
     for(hypothesis in hypotheses) {
       options$hypothesis <- hypothesis
       results <- jaspTools::runAnalysis("ContingencyTablesBayesian", "test.csv", options, view = FALSE)
-      table <- results[["results"]][["container1"]][["collection"]][["container1_contTabBasBF"]][["data"]]
+      table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_contTabBasBF"]][["data"]]
       #makeTestTable(table)
       jaspTools::expect_equal_tables(table, refTables[[samplingModel]][[hypothesis]], label=paste("Sampling model", samplingModel, "; hypothesis", hypothesis))
     }
@@ -123,7 +120,7 @@ test_that("Log Odds Ratio table results match", {
   options$oddsRatio <- TRUE
   options$oddsRatioCredibleIntervalInterval <- 0.90
   results <- jaspTools::runAnalysis("ContingencyTablesBayesian", "test.csv", options)
-  table <- results[["results"]][["container1"]][["collection"]][["container1_contTabBasLogOdds"]][["data"]]
+  table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_contTabBasLogOdds"]][["data"]]
   jaspTools::expect_equal_tables(table,
     list(-0.322626350332064, -0.98462219921522, 0.339369498551093)
   )
@@ -137,7 +134,7 @@ test_that("Cramer's V table results match", {
   options$effectSize <- TRUE
   options$effectSizeCredibleIntervalInterval <- 0.90
   results <- jaspTools::runAnalysis("ContingencyTablesBayesian", "test.csv", options)
-  table <- results[["results"]][["container1"]][["collection"]][["container1_contTabBasCramersV"]][["data"]]
+  table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_contTabBasCramersV"]][["data"]]
   jaspTools::expect_equal_tables(table,
                       list(0.0698837782777569, 1.02065076979155e-16, 0.216657039422164)
   )

--- a/tests/testthat/test-verified-contingencytables.R
+++ b/tests/testthat/test-verified-contingencytables.R
@@ -14,8 +14,8 @@ results <- jaspTools::runAnalysis("ContingencyTables", "chisquare2.csv", options
 # https://jasp-stats.github.io/jasp-verification-project/frequencies.html#chi-squared-test
 test_that("Main table results match R, SPSS, SAS, Minitab", {
   # Main table
-  resultTable   <- results[["results"]][["container1"]][["collection"]][["container1_crossTabMain"]][["data"]]
-  
+  resultTable   <- results[["results"]][["container_Preference_Sex"]][["collection"]][["container_Preference_Sex_crossTabMain"]][["data"]]
+
   jaspTools::expect_equal_tables(
     "test"=resultTable,
     "ref"=list("TRUE", 32, 19, "Fiction", 51, 20, 29, "Nonfiction", 49, "TRUE",
@@ -26,8 +26,8 @@ test_that("Main table results match R, SPSS, SAS, Minitab", {
 # https://jasp-stats.github.io/jasp-verification-project/frequencies.html#chi-squared-test
 test_that("Chi-squared table results match R, SPSS, SAS, Minitab", {
   # Chi-squared table
-  resultTable   <- results[["results"]][["container1"]][["collection"]][["container1_crossTabChisq"]][["data"]]
-  
+  resultTable   <- results[["results"]][["container_Preference_Sex"]][["collection"]][["container_Preference_Sex_crossTabChisq"]][["data"]]
+
   jaspTools::expect_equal_tables(
     "test"=resultTable,
     "ref"=list("", 1, "", 0.0282214233450228, "N", "<unicode><unicode>", 100,


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/908

The problem was that the names of the container in the state were indexed by number. 
So if we had tableA and tableB in the slots state_1->tableA, state_2->tableB and the tableA was removed, then we'd have state[2]->tableB still but also add an additional state[1]->tableB

I couldn't test it as thoroughly as I'd liked because the dynamic module install crashes my JASP.