### PR TITLE
Issue #913 fix - Added normal contingency tables 

### DIFF
--- a/inst/qml/ContingencyTables.qml
+++ b/inst/qml/ContingencyTables.qml
@@ -45,6 +45,20 @@ Form
 
 		Group
 		{
+		    CheckBox
+			{
+				name: "oddsRatioNormal"; label: qsTr("Odds ratio (2x2 only)")
+				CIField { name: "oddsRatioConfidenceIntervalIntervalNormal"; label: qsTr("Confidence interval") }
+				RadioButtonGroup
+				{
+					title: qsTr("Alt. Hypothesis (Fisher's exact test)")
+					name: "oddsRatioHypothesisNormal"
+					RadioButton { value: "two.sided";	label: qsTr("Group one ≠ Group two"); checked: true	}
+					RadioButton { value: "greater";		label: qsTr("Group one > Group two")				}
+					RadioButton { value: "less";		label: qsTr("Group one < Group two")				}
+				}
+			}
+			
 			CheckBox
 			{
 				name: "oddsRatio"; label: qsTr("Log odds ratio (2x2 only)")
@@ -58,6 +72,8 @@ Form
 					RadioButton { value: "less";		label: qsTr("Group one < Group two")				}
 				}
 			}
+			
+
 		}
 
 		Group


### PR DESCRIPTION
This push adds the normal (non-log) contingency tables as discussed in issue #913. I took the QML and R code from the logarithmic contingency tables to serve as the base for the non-logarithmic ones. 
![Issue #913](https://user-images.githubusercontent.com/75808551/104849580-b52aba80-58ea-11eb-8614-bda7dea012b1.png)
