### PR TITLE
Show a more informative footnote when the phi coefficient cannot be computed + added a unit test

### DIFF
--- a/R/contingencytables.R
+++ b/R/contingencytables.R
@@ -550,20 +550,27 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
   })
 
   if (ready) {
+
     chi.result <- try(vcd::assocstats(counts.matrix))
 
-    if (isTryError(chi.result))
-      row[[paste0("value[", type, "]")]] <- NaN
-    else if (is.na(chi.result[[val]])) {
-      row[[paste0("value[", type, "]")]] <- NaN
-      message                            <- gettext("Value could not be calculated - At least one row or column contains all zeros")
+    colName <- paste0("value[", type, "]")
 
-      analysisContainer[["crossTabNominal"]]$addFootnote(message, rowNames = rowname, colNames = paste0("value[", type, "]"))
+    if (isTryError(chi.result))
+      row[[colName]] <- NaN
+    else if (is.na(chi.result[[val]])) {
+      row[[colName]] <- NaN
+
+      message <- if (val == "phi" && !all(dim(counts.matrix) == 2L))
+        gettext("Phi coefficient is only available for 2 by 2 contingency Tables")
+      else
+        gettext("Value could not be calculated - At least one row or column contains all zeros")
+
+      analysisContainer[["crossTabNominal"]]$addFootnote(message, rowNames = rowname, colNames = colName)
     } else
-      row[[paste0("value[", type, "]")]] <- chi.result[[val]]
+      row[[colName]] <- chi.result[[val]]
   }
   else
-    row[[paste0("value[", type, "]")]] <- "."
+    row[[colName]] <- "."
 
   return(row)
 }

--- a/tests/testthat/test-contingencytables.R
+++ b/tests/testthat/test-contingencytables.R
@@ -186,3 +186,31 @@ test_that("Analysis handles errors", {
   errorMsg <- results[["results"]][["errorMessage"]]
   expect_is(errorMsg, "character")
 })
+
+
+options <- analysisOptions("ContingencyTables")
+options$columns <- "V2"
+options$contingencyCoefficient <- TRUE
+options$phiAndCramersV <- TRUE
+options$rows <- "V1"
+set.seed(1)
+# data is a random sample from https://github.com/jasp-stats/jasp-issues/issues/811
+dataset <- structure(list(V1 = c(1L, 2L, 1L, 2L, 1L, 0L, 2L, 0L, 0L, 1L), V2 = c(0L, 0L, 1L, 0L, 0L, 1L, 0L, 1L, 1L, 0L)), row.names = c(NA, -10L), class = "data.frame")
+results <- runAnalysis("ContingencyTables", dataset, options)
+
+test_that("Phi coefficient is only available for 2 by 2 contingency tables", {
+  tb <- results[["results"]][["container1"]][["collection"]][["container1_crossTabNominal"]]
+  table <- tb[["data"]]
+  jaspTools::expect_equal_tables(
+    test  = table,
+    ref   = list("Contingency coefficient", "Cramer's V ", "Phi-coefficient", 0.638284738504225, 0.82915619758885, "NaN"),
+    label = "values in the table"
+  )
+
+  footnote <- tb[["footnotes"]]
+  jaspTools::expect_equal_tables(
+    test  = footnote,
+    ref   = list("value[PhiCoef]", 15, 0, "Phi coefficient is only available for 2 by 2 contingency Tables"),
+    label = "footnote under the table"
+  )
+})


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/811

`vcd::assocstats` checks if `all(dim(counts.matrix) == 2L)` and if not it returns NA.