### PR TITLE
Convert priors and hypotheses from tables to numeric 

### DIFF
--- a/R/multinomialtest.R
+++ b/R/multinomialtest.R
@@ -18,12 +18,12 @@
 MultinomialTest <- function(jaspResults, dataset, options, ...) {
   # Read dataset
   dataset <- .multinomReadData(dataset, options)
-  
+
   ready   <- options$factor != ""
 
   # Error checking
   .multinomCheckErrors(dataset, options)
-  
+
   # Output tables and plots
   .multinomialMainTable(        jaspResults, dataset, options, ready)
   .multinomialDescriptivesTable(jaspResults, dataset, options, ready)
@@ -43,77 +43,77 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
         asnum <- c(asnum, options$exProbVar)
     }
   }
-  
+
   if (is.null(dataset)) {
     dataset <- .readDataSetToEnd(columns.as.numeric = asnum, columns.as.factor = fact,
                                  exclude.na.listwise = NULL)
   } else {
     dataset <- .vdf(dataset, columns.as.numeric = asnum, columns.as.factor = fact)
   }
-  
+
   # Reorder the rows of the factor and the counts (and expected probabilities) if the user changes the factor level order in JASP.
   # This ensures the ordering in tables and plots also changes appropriately.
   if (options$factor != "" && options$counts != "") {
-    factLevelOrder        <- as.character(dataset[[.v(options$factor)]])   
-    
+    factLevelOrder        <- as.character(dataset[[.v(options$factor)]])
+
     # the following condition holds when `counts` are specified but the data set is not in aggregated form
     # the error is subsequently caught in  .multinomCheckErrors
     # we need to escape this function early because the operations under this check assume that the data set is already in aggregated form
     if(length(unique(factLevelOrder)) != length(factLevelOrder)) return(dataset)
-    
+
     levelOrderUserWants   <- options$tableWidget[[1]]$levels
     whatUserWantsToWhatIs <- match(levelOrderUserWants, factLevelOrder)
-      
+
     if (!identical(sort(whatUserWantsToWhatIs), whatUserWantsToWhatIs))
       dataset[seq_along(factLevelOrder), ] <- dataset[whatUserWantsToWhatIs, ]
-    
+
     # For syntax mode the analysis will be called from RStudio and the factor levels may not match the tableWidget.
     factValues <- as.character(dataset[[.v(options$factor)]])
     facLevels  <- levels(dataset[[.v(options$factor)]])
     if (length(facLevels) == length(factValues) && !identical(factValues, facLevels))
       levels(dataset[[.v(options$factor)]]) <- factValues
   }
-  
+
   return(dataset)
 }
 
 .multinomCheckErrors <- function(dataset, options) {
   if (options$factor == "")
     return()
-  
+
   customChecks <- list(
     checkExpecAndObs = function() {
-      if (options$exProbVar != "" && options$counts == "") 
+      if (options$exProbVar != "" && options$counts == "")
         return(gettext("Expected counts not supported without observed counts."))
     },
-    
+
     checkExpecNeeded = function() {
       if (options$exProbVar != "" || options$hypothesis != "multinomialTest")
         if (options$exProbVar == "" && length(options$tableWidget) == 0)
           return(gettext("No expected counts entered."))
     },
-    
+
     checkCounts = function() {
       if (options$counts != "") {
         dataset <- na.omit(dataset)
         nlevels <- nlevels(as.factor(dataset[[.v(options$factor)]]))
         counts  <- dataset[[.v(options$counts)]]
-        
+
         if (nlevels != length(counts))
           return(gettext("Invalid counts: variable does not match the number of levels of the factor. When counts are specified, each row of the data set must represent a unique level of the factor."))
 
         if (options$exProbVar != "" && nlevels != length(dataset[[.v(options$exProbVar)]]))
           return(gettext("Invalid expected counts: variable does not match the number of levels of the factor."))
-        
+
         # only applies for observed counts, expected counts can be proportions
         if (options$exProbVar == "" && !all(counts == round(counts)))
           return(gettext("Invalid counts: variable must contain only integer values."))
       }
     }
   )
-  
-  .hasErrors(dataset, 
-             type = c("factorLevels", "negativeValues", "infinity"), 
+
+  .hasErrors(dataset,
+             type = c("factorLevels", "negativeValues", "infinity"),
              negativeValues.target = c(options$counts, options$exProbVar),
              infinity.target = c(options$counts, options$exProbVar),
              factorLevels.target  = options$factor,
@@ -133,34 +133,34 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
   #
   # Return:
   #   No return, stores jaspResults Object (chisquare test)
- 
+
   # Take results from state if possible
-  if (!is.null(jaspResults[["stateChisqResults"]])) 
+  if (!is.null(jaspResults[["stateChisqResults"]]))
     return(jaspResults[["stateChisqResults"]]$object)
-  
+
   chisqResults <- NULL
   fact <- options$factor
-  
+
   if(fact != ""){
     # first determine the hypotheses
     factorVariable <- dataset[[.v(fact)]]
     factorVariable <- factorVariable[!is.na(factorVariable)]
     factorVariable <- as.factor(factorVariable)
     nlev <- nlevels(factorVariable)
-    
+
     if (options$counts != "") {
       counts <- dataset[[.v(options$counts)]]
       # omit count entries for which factor variable is NA
       counts <- counts[!is.na(factorVariable)]
       c <- dataset[[.v(options$counts)]]
-      factorVariable <- factor(rep(factorVariable, c), 
+      factorVariable <- factor(rep(factorVariable, c),
                                levels = levels(factorVariable))
-    } 
-    
+    }
+
     dataTable <- table(factorVariable)
-    
+
     hyps <- .multinomialHypotheses(dataset, options, nlev)
-    
+
     # create a named list with as values the chi-square result objects
     chisqResults <- lapply(hyps, function(h) {
       # catch warning message and append to object if necessary
@@ -177,14 +177,14 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
   }
   # Save results to state
   jaspResults[["stateChisqResults"]] <- createJaspState(chisqResults)
-  jaspResults[["stateChisqResults"]]$dependOn(c("factor", "counts", "hypothesis", 
+  jaspResults[["stateChisqResults"]]$dependOn(c("factor", "counts", "hypothesis",
                                                 "exProbVar", "tableWidget", "simulatepval"))
   return(chisqResults)
 }
 
 # Filling Tables ----
 .multinomMainTableFill <- function(jaspResults, dataset, options) {
-  # Turn chi-square object into jaspResults 
+  # Turn chi-square object into jaspResults
   # object and creates results for descripties table
   #
   # Args:
@@ -192,27 +192,27 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
   #   dataset: input dataset
   #   options: user options
   #   chisqResults:
-  #   
+  #
   # Return:
   #   No return, stores jaspResults Object (main table results)
-  
+
   results <- list()
 
   # Compute Results
   chisqResults <- .chisquareTest(jaspResults, dataset, options)
-  
+
   if(!is.null(chisqResults)){
     # extract relevant objects from chisqResults (this looks so convoluted is because its stored in an inconvenient way, but that's probably a legacy code thingy).
-    dataframe <- do.call(rbind.data.frame, 
+    dataframe <- do.call(rbind.data.frame,
                          lapply(chisqResults, function(x) c(x[["statistic"]][["X-squared"]], x[["parameter"]][["df"]], x[["p.value"]])))
     colnames(dataframe) <- c("chisquare", "df", "p")
     dataframe <- cbind(case = names(chisqResults), dataframe)
-    
+
     if (options$VovkSellkeMPR)
       dataframe <- cbind(dataframe, VovkSellkeMPR = VovkSellkeMPR(dataframe$p))
-    
+
     jaspResults[["chisqTable"]]$setData(dataframe)
-    
+
     for (r in 1:length(chisqResults)) {
       if (!is.null(chisqResults[[r]][["warn"]]))
         jaspResults[["chisqTable"]]$addFootnote(chisqResults[[r]][["warn"]])
@@ -221,26 +221,26 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
 }
 
 .multinomDescriptivesTableFill <- function(jaspResults, options, chisqResults){
-  # Turn chi-square object into jaspResults 
+  # Turn chi-square object into jaspResults
   # object and creates results for descripties table
   #
   # Args:
   #   jaspResults:
   #   dataset: input dataset
   #   options: user options
-  #   
+  #
   # Return:
   #   No return, stores jaspResults Object (descriptives table results)
-  
+
   results <- list()
   footnotes <- list()
 
   observed <- chisqResults[[1]][["observed"]]
   if (options$countProp == "descCounts")
     observed <- as.integer(observed)
-  else 
+  else
     observed <- as.numeric(observed)/sum(observed)
-  
+
   nms <- names(chisqResults)
   tableFrame <- data.frame(
     factor   = names(chisqResults[[1]][["observed"]]),
@@ -255,16 +255,16 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
       div <- sum(chisqResults[[1]][["observed"]])
       tableFrame <- cbind(tableFrame, r[["expected"]]/div)
     }
-  
+
   if (length(nms) == 1)
     colnames(tableFrame)[-(1:2)] <- "expected"
-  else 
+  else
     colnames(tableFrame)[-(1:2)] <- nms
-  
+
   # Add confidenceInterval to the tableFrame
   if (options$confidenceInterval){
-    ciDf <- .multComputeCIs(chisqResults[[1]][["observed"]], 
-                            options$confidenceIntervalInterval, 
+    ciDf <- .multComputeCIs(chisqResults[[1]][["observed"]],
+                            options$confidenceIntervalInterval,
                             scale = options$countProp)
     tableFrame <- cbind(tableFrame, ciDf)
     message <- gettext("Confidence intervals are based on independent binomial distributions.")
@@ -290,29 +290,29 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
   #
   # Return:
   #   Chi square table
-  
+
   if (!is.null(jaspResults[["chisqTable"]])) return()
-  
+
   # Create table
   chisqTable <- createJaspTable(title = "Multinomial Test")
   chisqTable$dependOn(c("factor", "counts", "exProbVar", "tableWidget",
                         "VovkSellkeMPR", "hypothesis"))
   chisqTable$showSpecifiedColumnsOnly <- TRUE
-  
+
   # Add columns to table
   chisqTable$addColumnInfo(name = "case",      title = "", type = "string", combine = TRUE)
   chisqTable$addColumnInfo(name = "chisquare", title = "\u03C7\u00B2", type = "number")
   chisqTable$addColumnInfo(name = "df",        title = gettext("df"), type = "integer")
   chisqTable$addColumnInfo(name = "p",         title = gettext("p"),  type = "pvalue")
-  
+
   # include Vovk-Selke p-ratio as columns
   if (options$VovkSellkeMPR) {
     chisqTable$addColumnInfo(name = "VovkSellkeMPR", title =  gettextf("VS-MPR%s", "\u002A"), type = "number")
     chisqTable$addFootnote(.messages("footnote", "VovkSellkeMPR"), symbol = "\u002A")
   }
-  
+
   jaspResults[["chisqTable"]] <- chisqTable
-  if (!ready) 
+  if (!ready)
     return()
   res <- try(.multinomMainTableFill(jaspResults, dataset, options))
   .multinomialSetError(res, chisqTable)
@@ -328,13 +328,13 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
   #
   # Return:
   #   Descriptives table
-  
-  if(!options$descriptives || !is.null(jaspResults[["descriptivesTable"]])) 
+
+  if(!options$descriptives || !is.null(jaspResults[["descriptivesTable"]]))
     return()
-  
+
   # Compute/get Results
   chisqResults <- .chisquareTest(jaspResults, dataset, options)
-  
+
   descriptivesTable <- createJaspTable(title = gettext("Descriptives"))
   descriptivesTable$dependOn(c("factor", "counts", "exProbVar",  "hypothesis", "countProp", "descriptives",
                                "confidenceInterval", "tableWidget", "confidenceIntervalInterval"))
@@ -353,21 +353,21 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
       descriptivesTable$addColumnInfo(name = "observed", title = gettext("Observed"), type = "number")
 
     nms <- names(chisqResults)
-    
+
     if (length(nms) == 1) {
       if (options$countProp == "descCounts")
-        descriptivesTable$addColumnInfo(name = "expected", title = gettextf("Expected: %s", nms), 
+        descriptivesTable$addColumnInfo(name = "expected", title = gettextf("Expected: %s", nms),
                                         type = "integer")
       else
-        descriptivesTable$addColumnInfo(name = "expected", title = gettextf("Expected: %s", nms), 
+        descriptivesTable$addColumnInfo(name = "expected", title = gettextf("Expected: %s", nms),
                                         type = "number")
     } else {
       for (i in 1:length(nms)) {
         if (options$countProp == "descCounts")
-          descriptivesTable$addColumnInfo(name = nms[i], title = nms[i], 
+          descriptivesTable$addColumnInfo(name = nms[i], title = nms[i],
                                           type = "integer", overtitle = gettext("Expected"))
         else
-          descriptivesTable$addColumnInfo(name = nms[i], title = nms[i], 
+          descriptivesTable$addColumnInfo(name = nms[i], title = nms[i],
                                           type = "number", overtitle = gettext("Expected"))
       }
     }
@@ -375,13 +375,13 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
   if (options$confidenceInterval){
     interval <- 100 * options$confidenceIntervalInterval
     title <- gettextf("%s%% Confidence Interval", interval)
-    descriptivesTable$addColumnInfo(name = "lowerCI", title = gettext("Lower"), 
+    descriptivesTable$addColumnInfo(name = "lowerCI", title = gettext("Lower"),
                                     type = "number", overtitle = title)
-    descriptivesTable$addColumnInfo(name = "upperCI", title = gettext("Upper"), 
+    descriptivesTable$addColumnInfo(name = "upperCI", title = gettext("Upper"),
                                     type = "number", overtitle = title)
   }
   jaspResults[["descriptivesTable"]] <- descriptivesTable
-  if (!ready) 
+  if (!ready)
     return()
   res <- try(.multinomDescriptivesTableFill(jaspResults, options, chisqResults))
   .multinomialSetError(res, descriptivesTable)
@@ -398,18 +398,18 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
 .multinomialDescriptivesPlot <- function(jaspResults, dataset, options, ready) {
   if(!options$descriptivesPlot || !is.null(jaspResults[["descriptivesPlot"]]))
     return()
-  
+
   descriptivesPlot <- createJaspPlot(title = gettext("Descriptives Plot"), width = 500, aspectRatio = 0.7)
-  descriptivesPlot$dependOn(c("factor", "counts", "descriptivesPlotConfidenceInterval", 
+  descriptivesPlot$dependOn(c("factor", "counts", "descriptivesPlotConfidenceInterval",
                               "countProp", "descriptivesPlot"))
-  
+
   jaspResults[["descriptivesPlot"]] <- descriptivesPlot
-  
+
   if (!ready)
     return()
-  
+
   .multinomialDescriptivesPlotFill(jaspResults, dataset, options, descriptivesPlot)
-  
+
   return()
 }
 
@@ -429,31 +429,31 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
     obs   <- as.numeric(chisqResults[[1]][["observed"]])/div
   }
   plotFrame <- cbind(plotFrame, obs)
-  
+
   # Calculate confidence interval
   if (options$descriptivesPlotConfidenceInterval){
-    ciDf       <- .multComputeCIs(chisqResults[[1]][["observed"]], 
-                                  options$descriptivesPlotConfidenceInterval, 
+    ciDf       <- .multComputeCIs(chisqResults[[1]][["observed"]],
+                                  options$descriptivesPlotConfidenceInterval,
                                   ifErrorReturn = 0, scale = options$countProp)
     plotFrame  <- cbind(plotFrame, ciDf)
   }
-  
+
   # Define custom y axis function
   base_breaks_y <- function(x){
     b <- pretty(c(0,x))
     d <- data.frame(x = -Inf, xend = -Inf, y = min(b), yend = max(b))
-    list(ggplot2::geom_segment(data = d, 
+    list(ggplot2::geom_segment(data = d,
                                ggplot2::aes(x = x, y = y, xend = xend, yend = yend),
                                size = 0.75, inherit.aes = FALSE),
          ggplot2::scale_y_continuous(breaks = b))
   }
-  
+
   # Determine y-axis margin: If CIs could not be computed, use observed counts
   plotFrame$yAxisMargin <- plotFrame$upperCI
   for(i in 1:nrow(plotFrame))
     if(abs(plotFrame$upperCI) <= sqrt(.Machine$double.eps)) #near-zero value
       plotFrame$yAxisMargin[i] <- plotFrame$obs[i]
-  
+
   # Create plot
   p <- ggplot2::ggplot(data = plotFrame,
                        mapping = ggplot2::aes(x = factor, y = obs)) +
@@ -463,7 +463,7 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
                            size = 0.75, width = 0.3) +
     base_breaks_y(plotFrame$yAxisMargin) +
     ggplot2::xlab(options$factor) + ggplot2::ylab(yname)
-  
+
   p <- jaspGraphs::themeJasp(p, horizontal = TRUE, xAxis = FALSE)
   descriptivesPlot$plotObject <- p
 }
@@ -480,7 +480,7 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
   #
   # Return:
   #   hypotheses
-  
+
   hyps <- list()
   if (options$exProbVar == "" && options$hypothesis == "multinomialTest") {
     # Expected probabilities are simple now
@@ -506,30 +506,30 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
   #
   # Return:
   #   expected Probabilities
-  
+
   if (options$exProbVar != "") {
     # use only exProbVar
     fact   <- dataset[[.v(options$factor)]]
     eProps <- dataset[.v(options$exProbVar)]
     colnames(eProps) <- options$exProbVar
     rownames(eProps) <- fact
-    
+
     return(na.omit(eProps))
 
   } else if (length(options$tableWidget) > 0) {
     eProps <- sapply(options$tableWidget, function(x) {
-      vals <- unlist(x$values)
+      vals <- as.numeric(unlist(x$values))
       if (sum(vals) == 0)
         vals <- rep(1, length(vals))
       return(vals)
     })
-    
-    colnames(eProps) <- sapply(seq_along(options$tableWidget), 
+
+    colnames(eProps) <- sapply(seq_along(options$tableWidget),
                                function(x) paste0("H\u2080 (", letters[x], ")"))
     rownames(eProps) <- options$tableWidget[[1]]$levels
-    
+
     return(as.data.frame(eProps))
-  } 
+  }
 }
 
 .multinomialSetError <- function(res, table){

--- a/R/multinomialtestbayesian.R
+++ b/R/multinomialtestbayesian.R
@@ -54,7 +54,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
 
   if (!multinomialResults$specs[["ready"]])
     return(multinomialResults)
-  
+
   # Prepare for running the Bayesian Multinomial test
   factorVariable <- multinomialResults$specs$factorVariable
   countVariable  <- multinomialResults$specs$countVariable
@@ -87,7 +87,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   multinomialResults$mainTable <- vector('list', length = nhyps)
 
   for(h in 1:nhyps){
-    multinomialResults$mainTable[[nms[h]]] <- .multBayesBfEquality(alphas = a, counts = dataTable, thetas = hyps[[h]])
+    multinomialResults$mainTable[[nms[h]]] <- .multBayesBfEquality(alphas = as.numeric(a), counts = dataTable, thetas = hyps[[h]])
   }
 
   multinomialResults$mainTable[["prior"]]   <- a
@@ -118,7 +118,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   multinomialResults$descriptivesTable[["descProps"]]    <- setNames(as.data.frame(multinomialResults$descriptivesTable[["descProps"]]), c("fact", "observed", nms))
   multinomialResults$descriptivesTable[["descCounts"]]   <- setNames(as.data.frame(multinomialResults$descriptivesTable[["descCounts"]]), c("fact", "observed", nms))
   multinomialResults$descriptivesTable[["descPropsCI"]]  <- .multComputeCIs(dataTable, options$credibleIntervalInterval, scale = "descProbs")
-  multinomialResults$descriptivesTable[["descCountsCI"]] <- .multComputeCIs(dataTable, options$credibleIntervalInterval, scale = "descCounts") 
+  multinomialResults$descriptivesTable[["descCountsCI"]] <- .multComputeCIs(dataTable, options$credibleIntervalInterval, scale = "descCounts")
 
   # Save results to state
   defaultOptions <- multinomialResults$specs$defaultOptions
@@ -200,7 +200,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
     descriptivesTable$dependOn(c("countProp", "descriptives", "credibleIntervalInterval"))
   } else {
     ciRequested   <- options$confidenceInterval
-    ciInterval    <- options$confidenceIntervalInterval 
+    ciInterval    <- options$confidenceIntervalInterval
     ciType  <- gettext("Confidence")
     tableFootnote <- gettext("Confidence intervals are based on independent binomial distributions.")
     descriptivesTable$dependOn(c("countProp", "descriptives", "confidenceIntervalInterval"))
@@ -240,7 +240,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
                                       overtitle = overTitle)
       descriptivesTable$addColumnInfo(name = "upperCI", title = gettext("Upper"), type = "number",
                                       overtitle = overTitle)
-    } 
+    }
 
   jaspResults[["multinomialDescriptivesTable"]] <- descriptivesTable
 
@@ -258,12 +258,12 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
     ciInfo <- multinomialResults[["descriptivesTable"]][[paste0(options$countProp, "CI")]]
     descDF <- cbind(descDF, ciInfo)
     descriptivesTable$addFootnote(tableFootnote)
-    
+
     if (any(is.nan(unlist(descDF[, c('lowerCI', 'upperCI')])))) {
       descriptivesTable$addFootnote(message = gettextf("Could not compute %s Intervals.", tolower(ciType)))
     }
-  } 
-  
+  }
+
   descriptivesTable$setData(descDF)
 }
 
@@ -301,15 +301,15 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   errorReturn <- rep(ifErrorReturn, 2)
   div         <- ifelse(scale == 'descCounts', sum(counts), 1)
   N           <- sum(counts)
-  
+
   ciDf   <- data.frame(lowerCI = NA, upperCI = NA)
   for(i in seq_along(counts)){
     # return results on count scale. If function crashes, return table with NaN's
-    tryCatch(binomResult <- binom.test(counts[i], N, conf.level = CI)$conf.int * div, 
+    tryCatch(binomResult <- binom.test(counts[i], N, conf.level = CI)$conf.int * div,
              error = function(e) {binomResult <<- errorReturn})
     ciDf[i, ] <- binomResult
   }
-  
+
   return(ciDf)
 }
 
@@ -347,13 +347,13 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   plotFrame <- multinomialResults[["descriptivesPlot"]][[options$countProp]]
   # We need to reverse the factor's levels because of the coord_flip later
   plotFrame$fact <- factor(plotFrame$fact, levels = rev(plotFrame$fact))
-  
+
   # Determine y-axis margin: If CIs could not be computed, use observed counts
   plotFrame$yAxisMargin <- plotFrame$upperCI
   for(i in 1:nrow(plotFrame)){
     if(plotFrame$upperCI[i] == 0){
       plotFrame$yAxisMargin[i] <- plotFrame$obs[i]
-    }   
+    }
   }
 
   # Create plot


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/1230
fixes https://github.com/jasp-stats/jasp-test-release/issues/1229
and strips trailing whitespace

The problem was that suddenly qml sends the values from elements like
```qml
		Chi2TestTableView
		{
			name			: "priorCounts"
			preferredWidth	: form.availableWidth - hypothesisGroup.leftPadding
			source			: "factor"
			visible			: factors.count > 0

			showAddButton		: false
			showDeleteButton	: false
			colHeader			: "Counts"
			itemType			: JASP.Integer
		}
```

as character, not numeric. This is a quick dirty fix but I think perhaps it would be more elegant to fix it in the qml itself. Should I make an issue for that for @boutinb to look into later?