### PR TITLE
Multinomial prior table, change cornertext from row to level

### DIFF
--- a/inst/qml/MultinomialTestBayesian.qml
+++ b/inst/qml/MultinomialTestBayesian.qml
@@ -123,7 +123,8 @@ Form
 
 			showAddButton		: false
 			showDeleteButton	: false
-			colHeader			: "Counts"
+			colHeader			: qsTr("Counts")
+			cornerText			: qsTr("Level #")
 			itemType			: JASP.Integer
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1475

The table now looks like this: 
![image](https://user-images.githubusercontent.com/21319932/130573664-15ceedaf-dc61-45f9-923f-d5546fded019.png)
