### PR TITLE
use jaspGraphs functions for axis line

### DIFF
--- a/R/multinomialtest.R
+++ b/R/multinomialtest.R
@@ -441,22 +441,13 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
     plotFrame  <- cbind(plotFrame, ciDf)
   }
 
-  # Define custom y axis function
-  base_breaks_y <- function(x){
-    b <- pretty(c(0,x))
-    d <- data.frame(x = -Inf, xend = -Inf, y = min(b), yend = max(b))
-    list(ggplot2::geom_segment(data = d,
-                               ggplot2::aes(x = x, y = y, xend = xend, yend = yend),
-                               size = 0.75, inherit.aes = FALSE),
-         ggplot2::scale_y_continuous(breaks = b))
-  }
-
   # Determine y-axis margin: If CIs could not be computed, use observed counts
   plotFrame$yAxisMargin <- plotFrame$upperCI
   for(i in 1:nrow(plotFrame))
-    if(abs(plotFrame$upperCI) <= sqrt(.Machine$double.eps)) #near-zero value
+    if(abs(plotFrame$upperCI[i]) <= sqrt(.Machine$double.eps)) #near-zero value
       plotFrame$yAxisMargin[i] <- plotFrame$obs[i]
 
+  yBreaks <- jaspGraphs::getPrettyAxisBreaks(c(0, plotFrame[["yAxisMargin"]]))
   # Create plot
   p <- ggplot2::ggplot(data = plotFrame,
                        mapping = ggplot2::aes(x = factor, y = obs)) +
@@ -464,10 +455,12 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
                       fill = "grey") +
     ggplot2::geom_errorbar(ggplot2::aes(ymin = ciDf$lowerCI, ymax = ciDf$upperCI),
                            size = 0.75, width = 0.3) +
-    base_breaks_y(plotFrame$yAxisMargin) +
-    ggplot2::xlab(options$factor) + ggplot2::ylab(yname)
+    ggplot2::xlab(options$factor) +
+    ggplot2::scale_y_continuous(name = yname, breaks = yBreaks) +
+    jaspGraphs::geom_rangeframe(sides = "b") +
+    ggplot2::coord_flip() +
+    jaspGraphs::themeJaspRaw(axis.title.cex = jaspGraphs::getGraphOption("axis.title.cex"))
 
-  p <- jaspGraphs::themeJasp(p, horizontal = TRUE, xAxis = FALSE)
   descriptivesPlot$plotObject <- p
 }
 

--- a/tests/testthat/_snaps/multinomialtest/descriptives-1.svg
+++ b/tests/testthat/_snaps/multinomialtest/descriptives-1.svg
@@ -27,28 +27,27 @@
 </defs>
 <g clip-path='url(#cpNTguMTV8NzIwLjAwfDIwLjcxfDUwNy4wOQ==)'>
 <rect x='58.15' y='20.71' width='661.85' height='486.39' style='stroke-width: 10.67; stroke: none;' />
-<rect x='88.24' y='34.74' width='401.12' height='84.18' style='stroke-width: 1.60; stroke-linecap: square; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='88.24' y='128.27' width='401.12' height='84.18' style='stroke-width: 1.60; stroke-linecap: square; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='88.24' y='221.81' width='401.12' height='84.18' style='stroke-width: 1.60; stroke-linecap: square; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='88.24' y='315.35' width='401.12' height='84.18' style='stroke-width: 1.60; stroke-linecap: square; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='88.24' y='408.88' width='401.12' height='84.18' style='stroke-width: 1.60; stroke-linecap: square; stroke-linejoin: miter; fill: #BEBEBE;' />
-<polyline points='673.56,90.86 673.56,62.80 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='673.56,76.83 342.26,76.83 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='342.26,90.86 342.26,62.80 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='673.56,184.40 673.56,156.33 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='673.56,170.37 342.26,170.37 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='342.26,184.40 342.26,156.33 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='673.56,277.93 673.56,249.87 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='673.56,263.90 342.26,263.90 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='342.26,277.93 342.26,249.87 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='673.56,371.47 673.56,343.41 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='673.56,357.44 342.26,357.44 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='342.26,371.47 342.26,343.41 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='673.56,465.00 673.56,436.94 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='673.56,450.97 342.26,450.97 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<polyline points='342.26,465.00 342.26,436.94 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<line x1='88.24' y1='507.09' x2='689.92' y2='507.09' style='stroke-width: 1.60; stroke-linecap: butt;' />
-<line x1='87.92' y1='507.09' x2='690.23' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='88.24' y='34.74' width='412.33' height='84.18' style='stroke-width: 1.60; stroke-linecap: square; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='88.24' y='128.27' width='412.33' height='84.18' style='stroke-width: 1.60; stroke-linecap: square; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='88.24' y='221.81' width='412.33' height='84.18' style='stroke-width: 1.60; stroke-linecap: square; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='88.24' y='315.35' width='412.33' height='84.18' style='stroke-width: 1.60; stroke-linecap: square; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='88.24' y='408.88' width='412.33' height='84.18' style='stroke-width: 1.60; stroke-linecap: square; stroke-linejoin: miter; fill: #BEBEBE;' />
+<polyline points='689.92,90.86 689.92,62.80 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='689.92,76.83 349.36,76.83 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='349.36,90.86 349.36,62.80 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='689.92,184.40 689.92,156.33 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='689.92,170.37 349.36,170.37 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='349.36,184.40 349.36,156.33 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='689.92,277.93 689.92,249.87 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='689.92,263.90 349.36,263.90 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='349.36,277.93 349.36,249.87 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='689.92,371.47 689.92,343.41 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='689.92,357.44 349.36,357.44 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='349.36,371.47 349.36,343.41 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='689.92,465.00 689.92,436.94 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='689.92,450.97 349.36,450.97 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<polyline points='349.36,465.00 349.36,436.94 ' style='stroke-width: 1.60; stroke-linecap: butt;' />
+<line x1='87.92' y1='507.09' x2='707.05' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <rect x='58.15' y='20.71' width='661.85' height='486.39' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
@@ -65,19 +64,19 @@
 <polyline points='49.65,76.83 58.15,76.83 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <polyline points='58.15,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
 <polyline points='88.24,515.60 88.24,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='188.52,515.60 188.52,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='288.80,515.60 288.80,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='389.08,515.60 389.08,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='489.36,515.60 489.36,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='589.64,515.60 589.64,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='689.92,515.60 689.92,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='191.32,515.60 191.32,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='294.40,515.60 294.40,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='397.48,515.60 397.48,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='500.57,515.60 500.57,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='603.65,515.60 603.65,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='706.73,515.60 706.73,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <text x='88.24' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='188.52' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>5</text>
-<text x='288.80' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='389.08' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>15</text>
-<text x='489.36' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='589.64' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text x='689.92' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='191.32' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='294.40' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='397.48' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='500.57' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='603.65' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='706.73' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>30</text>
 <text x='389.08' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='154.26px' lengthAdjust='spacingAndGlyphs'>Observed counts</text>
 <text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='65.77px' lengthAdjust='spacingAndGlyphs'>facFive</text>
 <text x='389.08' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='104.90px' lengthAdjust='spacingAndGlyphs'>descriptives-1</text>


### PR DESCRIPTION
Fixes the first issue of https://github.com/jasp-stats/jasp-test-release/issues/1507

the jaspGraphs functions create the axes lines at draw time, so they will resize properly when people edit figures. The base_breaks functions determine these bounds statically, so they don't interact nicely with plot editing.