### PR TITLE
Allow phi coefficient to be negative

### DIFF
--- a/R/contingencytables.R
+++ b/R/contingencytables.R
@@ -565,7 +565,15 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 
   if (ready) {
 
-    chi.result <- try(vcd::assocstats(counts.matrix))
+    chi.result <- try({
+
+      res <- vcd::assocstats(counts.matrix)
+      # vcd::assocstats only returns absolute the value
+      if (val == "phi" && (counts.matrix[1, 1] * counts.matrix[2, 2] - counts.matrix[1, 2] * counts.matrix[1, 2]) < 0) {
+        res[[val]] <- -1 * res[[val]]
+      }
+      res
+    })
 
     colName <- paste0("value[", type, "]")
 

--- a/tests/testthat/test-contingencytables.R
+++ b/tests/testthat/test-contingencytables.R
@@ -105,7 +105,7 @@ test_that("Nominal table results match", {
   table <- results[["results"]][["container_facExperim_contBinom"]][["collection"]][["container_facExperim_contBinom_crossTabNominal"]][["data"]]
   jaspTools::expect_equal_tables(table,
     list("Contingency coefficient", 0.0807792391722019, "Phi-coefficient",
-         0.0810440898473108, "Cramer's V ", 0.0810440898473108)
+         -0.0810440898473108, "Cramer's V ", 0.0810440898473108)
   )
 })
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1325

For some reason `vcd::assocstats` always returns the absolute value of the phi coefficient. So just multiply it with -1 if needed.
