### PR TITLE
Clarify bayesian binomial priors

### DIFF
--- a/R/binomialtestbayesian.R
+++ b/R/binomialtestbayesian.R
@@ -37,22 +37,22 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
 .bayesBinomComputeResults <- function(jaspResults, dataset, options) {
   if (!is.null(jaspResults[["binomResults"]]))
     return(jaspResults[["binomResults"]]$object)
-  
+
   # This will be the object that we fill with results
   results <- list()
   hyp <- .binomTransformHypothesis(options$hypothesis)
-  
+
   for (variable in options$variables) {
-    
+
     results[[variable]] <- list()
-    
+
     data <- na.omit(dataset[[.v(variable)]])
-    
+
     for (level in levels(data)) {
-      
+
       counts <- sum(data == level)
       BF10  <- .bayesBinomialTest(counts, length(data), theta0=options$testValue, hypothesis = hyp, a = options$priorA, b = options$priorB)
-      
+
       # Add results for each level of each variable to results object
       results[[variable]][[level]] <- list(
         case          = variable,
@@ -64,16 +64,16 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
         BF01          = 1/BF10,
         LogBF10       = log(BF10)
       )
-    
+
     }
   }
-  
+
   # Save results to state
   jaspResults[["binomResults"]] <- createJaspState(results)
   jaspResults[["binomResults"]]$dependOn(
     c("variables", "testValue", "hypothesis", "priorA", "priorB")
   )
-  
+
   # Return results object
   return(results)
 }
@@ -82,18 +82,18 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
 .bayesBinomTableMain <- function(jaspResults, dataset, options, ready){
   if (!is.null(jaspResults[["binomTable"]]))
     return()
-  
+
   binomTable <- createJaspTable(gettext("Bayesian Binomial Test"))
   binomTable$dependOn(c("variables", "testValue", "hypothesis", "bayesFactorType", "priorA", "priorB"))
   binomTable$position <- 1
   binomTable$showSpecifiedColumnsOnly <- TRUE
-  
+
   binomTable$addCitation(c(
     "Jeffreys, H. (1961). Theory of Probability. Oxford, Oxford University Press.",
     "O'Hagan, A., & Forster, J. (2004). Kendall's advanced theory of statistics vol. 2B: Bayesian inference (2nd ed.). London: Arnold.",
     "Haldane, J. B. S. (1932). A note on inverse probability. Mathematical Proceedings of the Cambridge Philosophical Society, 28, 55-61."
   ))
-  
+
   bfTitleSpec <- list(null="\u2080")
   if (options$hypothesis == "notEqualToTestValue")
     bfTitleSpec[["other"]] <- "\u2081"
@@ -101,7 +101,7 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
     bfTitleSpec[["other"]] <- "\u208A"
   else if (options$hypothesis == "lessThanTestValue")
     bfTitleSpec[["other"]] <- "\u208B"
-  
+
   bfType <- options$bayesFactorType
   if (grepl("BF10", bfType)) {
     bfTitle <- paste0("BF", bfTitleSpec[["other"]], bfTitleSpec[["null"]])
@@ -110,14 +110,14 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
   } else {
     bfTitle <- paste0("BF", bfTitleSpec[["null"]], bfTitleSpec[["other"]])
   }
-  
+
   binomTable$addColumnInfo(name = "case",       title = "",                    type = "string", combine = TRUE)
   binomTable$addColumnInfo(name = "level",      title = gettext("Level"),      type = "string")
   binomTable$addColumnInfo(name = "counts",     title = gettext("Counts"),     type = "integer")
   binomTable$addColumnInfo(name = "total",      title = gettext("Total"),      type = "integer")
   binomTable$addColumnInfo(name = "proportion", title = gettext("Proportion"), type = "number")
   binomTable$addColumnInfo(name = bfType,       title = bfTitle,               type = "number")
-  
+
   if (options$hypothesis == "lessThanTestValue")
     note <- gettextf("For all tests, the alternative hypothesis specifies that the proportion is less than %s.", options$testValueUnparsed)
   else if (options$hypothesis == "greaterThanTestValue")
@@ -125,109 +125,111 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
   else
     note <- gettextf("Proportions tested against value: %s.", options$testValueUnparsed)
 
+  note <- gettextf("%1$s Shape of the prior distribution under the alternative hypothesis is specified by Beta(%2$s, %3$s).", note, options[["priorAUnparsed"]], options[["priorBUnparsed"]])
+
   binomTable$addFootnote(message = note)
 
   jaspResults[["binomTable"]] <- binomTable
 
   if (!ready)
     return()
-  
+
   binomTable$setExpectedSize(sum(unlist(lapply(dataset, nlevels))))
-    
+
   bayesBinomResults <- .bayesBinomComputeResults(jaspResults, dataset, options)
-  
+
   # we can use the frequentist function for this
   .binomFillTableMain(binomTable, bayesBinomResults)
 }
 
 #Bayes Factor Computation ----
 .bayesBinomialTest.twoSided <- function(counts, n, theta0, a, b) {
-  
+
   if (theta0 == 0 && counts == 0) {
-    
+
     # in this case, counts*log(theta0) should be zero, omit to avoid numerical issue with log(0)
-    
+
     logBF10 <- lbeta(counts + a, n - counts + b) -  lbeta(a, b) - (n - counts)*log(1 - theta0)
-    
+
   } else if (theta0 == 1 && counts == n) {
-    
+
     # in this case, (n - counts)*log(1 - theta0) should be zero, omit to avoid numerical issue with log(0)
-    
-    logBF10 <- lbeta(counts + a, n - counts + b) -  lbeta(a, b) - counts*log(theta0) 
-    
+
+    logBF10 <- lbeta(counts + a, n - counts + b) -  lbeta(a, b) - counts*log(theta0)
+
   } else {
-    
+
     logBF10 <- lbeta(counts + a, n - counts + b) -  lbeta(a, b) - counts*log(theta0) - (n - counts)*log(1 - theta0)
   }
-  
+
   BF10 <- exp(logBF10)
-  
+
   return(BF10)
-  
+
 }
 
 .bayesBinomialTest.oneSided <- function(counts, n, theta0, a, b, hypothesis) {
-  
+
   if (hypothesis == "less") {
-    
+
     lowerTail <- TRUE
-    
+
   } else if (hypothesis == "greater") {
-    
+
     lowerTail <- FALSE
-    
+
   }
-  
+
   if (theta0 == 0 && counts == 0) {
-    
+
     # in this case, counts*log(theta0) should be zero, omit to avoid numerical issue with log(0)
     logMLikelihoodH0 <- (n - counts)*log(1 - theta0)
-    
+
   } else if (theta0 == 1 && counts == n) {
-    
+
     # in this case, (n - counts)*log(1 - theta0) should be zero, omit to avoid numerical issue with log(0)
     logMLikelihoodH0 <- counts*log(theta0)
-    
+
   } else {
-    
+
     logMLikelihoodH0 <- counts*log(theta0) + (n - counts)*log(1 - theta0)
-    
+
   }
-  
+
   term1 <- pbeta(theta0, a + counts, b + n - counts, lower.tail = lowerTail, log.p = TRUE) +
     lbeta(a + counts, b + n - counts)
   term2 <- lbeta(a,b) + pbeta(theta0, a, b, lower.tail = lowerTail, log.p = TRUE)
   logMLikelihoodH1 <- term1 - term2
   BF10 <- exp(logMLikelihoodH1 - logMLikelihoodH0)
-  
+
   return(BF10)
-  
+
 }
 
 .bayesBinomialTest <- function(counts, n, theta0, hypothesis, a, b) {
-  
+
   if (hypothesis == "two.sided") {
-    
+
     BF10 <- try(.bayesBinomialTest.twoSided(counts, n, theta0, a, b), silent = TRUE)
-    
+
   } else {
-    
+
     #if (theta0 == 0 || theta0 == 1) {
-    #	
+    #
     #	BF10 <- NA
-    #	
+    #
     #} else {
-    
+
     BF10 <- try(.bayesBinomialTest.oneSided(counts, n, theta0, a, b, hypothesis), silent = TRUE)
-    
+
     #}
   }
-  
+
   if (isTryError(BF10))
     BF10 <- NA
-  
+
   return(BF10)
-  
+
 }
 
 .bayesBinomGetSubscript <- function(hypothesis) {
@@ -243,8 +245,8 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
 .bayesBinomInferentialPlots <- function(jaspResults, dataset, options, ready) {
   if (!options$plotPriorAndPosterior && !options$plotSequentialAnalysis)
     return()
-  
-  if (is.null(jaspResults[["inferentialPlots"]])) { 
+
+  if (is.null(jaspResults[["inferentialPlots"]])) {
     inferentialPlots <- createJaspContainer(gettext("Inferential Plots"))
     inferentialPlots$dependOn(c("testValue", "priorA", "priorB", "hypothesis"))
     inferentialPlots$position <- 2
@@ -258,18 +260,18 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
     inferentialPlots[["placeholder"]] <- createJaspPlot(width = 530, height = 400, dependencies = "variables")
     return()
   }
-  
+
   hyp <- .binomTransformHypothesis(options$hypothesis)
-  
+
   for (var in options$variables) {
-    
+
     data <- na.omit(dataset[[.v(var)]])
     if (length(data) == 0)
       next
-      
+
     for (level in levels(data)) {
       id <- paste0(var, " - ", level)
-      
+
       if (is.null(inferentialPlots[[id]])) {
         levelPlotContainer <- createJaspContainer(title = id)
         levelPlotContainer$dependOn(optionContainsValue=list(variables=var))
@@ -277,55 +279,55 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
       } else {
         levelPlotContainer <- inferentialPlots[[id]]
       }
-      
+
       counts <- sum(data == level)
       BF10   <- .bayesBinomialTest(counts, length(data), options$testValue, hypothesis = hyp, a = options$priorA, b = options$priorB)
 
       plotName <- paste0(var, level, "priorposterior")
       .bayesBinomPriorPosteriorPlot(levelPlotContainer, plotName, options, BF10, counts, length(data), hyp)
-      
+
       plotName <- paste0(var, level, "sequential")
       .bayesBinomSequentialPlot(levelPlotContainer, plotName, options, BF10, counts, length(data), hyp, var, data, level)
     }
-    
+
   }
 }
 
 .bayesBinomPriorPosteriorPlot <- function(container, plotName, options, BF10, counts, n, hyp) {
   if (!options$plotPriorAndPosterior || !is.null(container[[plotName]]))
     return()
-  
+
   plot <- createJaspPlot(title = gettext("Prior and Posterior"), width = 530, height = 400, aspectRatio = 0.7)
   plot$dependOn(c("plotPriorAndPosterior", "plotPriorAndPosteriorAdditionalInfo"))
-  
-  container[[plotName]] <- plot 
+
+  container[[plotName]] <- plot
 
   bfSubscripts <- .bayesBinomGetSubscript(options$hypothesis)
   quantiles <- .credibleIntervalPlusMedian(credibleIntervalInterval = .95, options$priorA, options$priorB, counts, n, hypothesis=hyp, theta0 = options$testValue)
   dfLinesPP <- .dfLinesPP(a=options$priorA, b=options$priorB, hyp = hyp, theta0 = options$testValue, counts = counts, n = n)
   dfPointsPP <- .dfPointsPP(a=options$priorA, b=options$priorB, hyp = hyp, theta0 = options$testValue, counts = counts, n = n)
   xName <- bquote(paste(.(gettext("Population proportion")), ~theta))
-  
+
   hypForPlots <- .binomHypothesisForPlots(hyp)
-  
+
   if (!options$plotPriorAndPosteriorAdditionalInfo)
     p <- jaspGraphs::PlotPriorAndPosterior(dfLines = dfLinesPP, dfPoints = dfPointsPP, xName = xName)
   else
     p <- jaspGraphs::PlotPriorAndPosterior(dfLines = dfLinesPP, dfPoints = dfPointsPP, xName = xName, BF = BF10, bfType = "BF10",
-                                           CRI = c(quantiles$ci.lower, quantiles$ci.upper), median = quantiles$ci.median, 
+                                           CRI = c(quantiles$ci.lower, quantiles$ci.upper), median = quantiles$ci.median,
                                            hypothesis = hypForPlots, drawCRItxt = TRUE)
   plot$plotObject <- p
 }
 
-.bayesBinomSequentialPlot <- function(container, plotName, options, BF10, counts, n, hyp, var, data, level) {   
+.bayesBinomSequentialPlot <- function(container, plotName, options, BF10, counts, n, hyp, var, data, level) {
   if (!options$plotSequentialAnalysis || !is.null(container[[plotName]]))
     return()
 
   plot <- createJaspPlot(title = gettext("Sequential Analysis"), width = 530, height = 400, aspectRatio = 0.7)
   plot$dependOn(c("plotSequentialAnalysis", "bayesFactorType"))
-  
+
   container[[plotName]] <- plot
-  
+
   hypForPlots <- .binomHypothesisForPlots(hyp)
 
   p <- try({
@@ -335,7 +337,7 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
     dfLinesSR   <- .dfLinesSR(d = data, var = var, split = level, a = options$priorA, b = options$priorB, hyp = hyp, theta0 = options$testValue, bfType = bfTypeIgnoreLog)
     jaspGraphs::PlotRobustnessSequential(dfLines = dfLinesSR, xName = "n", BF = bf, bfType = bfTypeIgnoreLog, hypothesis = hypForPlots)
   })
-  
+
   if (inherits(p, "try-error"))
     plot$setError(.extractErrorMessage(p))
   else
@@ -344,11 +346,11 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
 
 .dfLinesPP <- function(dataset, a = 1, b = 1, hyp = "two-sided", theta0 = .5, counts, n){
   if (a == 1 && b == 1) {
-    
+
     theta <- seq(0, 1, length.out = 1000)
 
   } else {
-    
+
     theta <- seq(0.001, 0.999, length.out = 1000)
   }
 
@@ -405,14 +407,14 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
   x <- 1 * (d == split)
   BF10 <- numeric(length(x))
   for (i in seq_along(x)) {
-    
+
     counts <- sum(x[1:i] == 1)
     n <- i  #length(x[1:i])
     BF10[i] <- .bayesBinomialTest(counts = counts, n = n, theta0, hyp, a, b)
-    
+
     if (is.na(BF10[i]))
       stop(gettext("One or more Bayes factors cannot be computed"))
-    
+
     if (is.infinite(BF10[i]))
       stop(gettext("One or more Bayes factors are infinite"))
   }
@@ -426,29 +428,29 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
 
 #CRI and Median ----
 .credibleIntervalPlusMedian <- function(credibleIntervalInterval = .95, a = 1, b = 1, counts = 10, n = 20, hypothesis = "two.sided", theta0 = .5) {
-  
+
   lower <- (1 - credibleIntervalInterval) / 2
   upper <- 1 - lower
-  
+
   if (hypothesis == "two.sided") {
-    
+
     quantiles <- qbeta(c(lower, .5, upper), a + counts , b + n - counts)
-    
+
   } else if (hypothesis == "greater") {
-    
+
     rightArea <- pbeta(theta0, a + counts , b + n - counts, lower.tail = FALSE)
     leftArea  <- 1 - rightArea
     quantiles <- qbeta(leftArea + rightArea * c(lower, .5, upper), a + counts , b + n - counts)
-    
+
   } else if (hypothesis == "less") {
-    
+
     leftArea  <- pbeta(theta0, a + counts , b + n - counts)
     quantiles <- qbeta(leftArea * c(lower, .5, upper), a + counts , b + n - counts)
-    
+
   }
-  
+
   return(list(ci.lower = quantiles[1], ci.median = quantiles[2], ci.upper = quantiles[3]))
-  
+
 }
 
 .binomHypothesisForPlots <- function(hyp){

--- a/R/binomialtestbayesian.R
+++ b/R/binomialtestbayesian.R
@@ -125,7 +125,7 @@ BinomialTestBayesian <- function(jaspResults, dataset = NULL, options, ...) {
   else
     note <- gettextf("Proportions tested against value: %s.", options$testValueUnparsed)
 
-  note <- gettextf("%1$s Shape of the prior distribution under the alternative hypothesis is specified by Beta(%2$s, %3$s).", note, options[["priorAUnparsed"]], options[["priorBUnparsed"]])
+  note <- gettextf("%1$s The shape of the prior distribution under the alternative hypothesis is specified by Beta(%2$s, %3$s).", note, options[["priorAUnparsed"]], options[["priorBUnparsed"]])
 
   binomTable$addFootnote(message = note)
 

--- a/inst/help/BinomialTestBayesian.md
+++ b/inst/help/BinomialTestBayesian.md
@@ -11,10 +11,13 @@ The Bayesian binomial test allows you to test whether a proportion of a dichotom
 
 - Test value: The proportion of the variable under the null hypothesis. By default, this is set to 0.5.
 
-#### Hypothesis
-- *&ne; Test value*: Two-sided alternative hypothesis that the proportion is not equal to test value.
-- *&gt; Test value*: One-sided alternative hypothesis that the proportion is larger than the test value.
-- *&lt; Test value*: One-sided alternative hypothesis that the proportion is smaller than the test value.
+#### Alt. Hypothesis
+- Direction
+  - *&ne; Test value*: Two-sided alternative hypothesis that the proportion is not equal to test value.
+  - *&gt; Test value*: One-sided alternative hypothesis that the proportion is larger than the test value.
+  - *&lt; Test value*: One-sided alternative hypothesis that the proportion is smaller than the test value.
+
+- Prior: **Beta** parameters *a* and *b* for the prior distribution under the alternative hypothesis. By default they are set to '1' each. This corresponds to a uniform prior distribution. See Learn Bayes module for more information and alternatives.
 
 #### Bayes Factor
 - BF<sub>10</sub>: By selecting this option, the Bayes factor will show evidence for the alternative hypothesis relative to the null hypothesis. This option is selected by default.
@@ -26,8 +29,6 @@ The Bayesian binomial test allows you to test whether a proportion of a dichotom
     - Additional info: Adds the Bayes factor computed with the user-defined prior; adds a probability wheel depicting the odds of the data under the null vs. alternative hypothesis; adds the median and the 95% credible interval of the posterior density of the effect size.
 - Sequential analysis: Displays the development of the Bayes factor as the data come in using the user-defined prior.
 
-#### Prior
-**Beta prior** parameters *a* and *b* are set to '1' each. This corresponds to a uniform prior.
 
 ### Output
 ---

--- a/inst/help/BinomialTestBayesian_nl.md
+++ b/inst/help/BinomialTestBayesian_nl.md
@@ -12,10 +12,13 @@ Met de bayesiaanse binomiaaltoets kan worden getoetst of de proportie van een di
 
 - Toetswaarde: De proportie van de variabele onder de nulhypothese. De standaardwaarde is 0.5. 
 
-#### Hypothesen
-- *&ne; Toets waarde*: Tweezijdige alternatieve hypothese dat de proportie niet gelijk is aan de toetswaarde. 
-- *&gt; Toets waarde*: Eenzijdige alternatieve hypothese dat de proportie hoger is dan de toetswaarde.
-- *&lt; Toets waarde*: Eenzijdige alternatieve hypothese dat de proportie lager is dan de toetswaarde.
+#### Alt. Hypothesen
+- Direction
+  - *&ne; Toets waarde*: Tweezijdige alternatieve hypothese dat de proportie niet gelijk is aan de toetswaarde. 
+  - *&gt; Toets waarde*: Eenzijdige alternatieve hypothese dat de proportie hoger is dan de toetswaarde.
+  - *&lt; Toets waarde*: Eenzijdige alternatieve hypothese dat de proportie lager is dan de toetswaarde.
+
+- Prior: **Beta**-parameters *a* en *b* voor de prioriteitsverdeling onder de alternatieve hypothese. Standaard zijn ze elk op '1' ingesteld. Dit komt overeen met een uniforme prior verdeling. Zie de module Learn Bayes voor meer informatie en alternatieven.
 
 #### Bayes factor
 - BF<sub>10</sub>: Als u deze optie selecteert geeft de Bayes factor bewijs voor de alternatieve hypothese ten opzichte van de nul hypothese. Dit is de standaardoptie. 
@@ -28,8 +31,6 @@ Met de bayesiaanse binomiaaltoets kan worden getoetst of de proportie van een di
 - Sequentiële analyse: Geeft de ontwikkeling van de Bayes factor weer terwijl de data binnenkomt. 
 
 
-#### Prior
-**Beta prior** parameters *a* en *b* staan standaard beide op '1'. Dit correspondeert met een uniforme prior.
 
 ### Uitvoer
 ---

--- a/inst/qml/BinomialTestBayesian.qml
+++ b/inst/qml/BinomialTestBayesian.qml
@@ -35,13 +35,25 @@ Form
 	
 	FormulaField { label: qsTr("Test value: "); name: "testValue"; value: "0.5" ; min:0; max: 1; Layout.columnSpan: 2 }
 	
-	RadioButtonGroup
+	Group
 	{
 		title: qsTr("Alt. Hypothesis")
-		name: "hypothesis"
-		RadioButton { value: "notEqualToTestValue";		label: qsTr("≠ Test value"); checked: true	}
-		RadioButton { value: "greaterThanTestValue";	label: qsTr("> Test value")					}
-		RadioButton { value: "lessThanTestValue";		label: qsTr("< Test value")					}
+
+		RadioButtonGroup
+		{
+			title: qsTr("Direction")
+			name: "hypothesis"
+			RadioButton { value: "notEqualToTestValue";		label: qsTr("≠ Test value"); checked: true	}
+			RadioButton { value: "greaterThanTestValue";	label: qsTr("> Test value")					}
+			RadioButton { value: "lessThanTestValue";		label: qsTr("< Test value")					}
+		}
+
+		Group
+		{
+			title: qsTr("Prior")
+			FormulaField { name: "priorA"; label: qsTr("Beta prior: parameter a"); value: "1"; min:0; max: 10000; inclusive: JASP.None }
+			FormulaField { name: "priorB"; label: qsTr("Beta prior: parameter b"); value: "1"; min:0; max: 10000; inclusive: JASP.None }
+		}
 	}
 
 	Group {
@@ -60,11 +72,4 @@ Form
 	}
 
 	BayesFactorType {}
-
-	Group
-	{
-		title: qsTr("Prior")
-		FormulaField { name: "priorA"; label: qsTr("Beta prior: parameter a"); value: "1"; min:0; max: 10000; inclusive: JASP.None }
-		FormulaField { name: "priorB"; label: qsTr("Beta prior: parameter b"); value: "1"; min:0; max: 10000; inclusive: JASP.None }
-	}
 }


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-issues/issues/1605

specifically:

1. Be clearer in the help files about the meaning of the beta priors.
2. Reorganize the input panel to put the beta priors under the "Alt. hypothesis" heading.
3. Improve the footnote to also display what kind of beta prior is used on the alternative hypothesis.

Please pay attention to the correctness of the dutch translation.