### PR TITLE
Row label of Odds Ratio now reflects Odds Ratio or Log Odds Ratio

### DIFF
--- a/R/contingencytables.R
+++ b/R/contingencytables.R
@@ -243,7 +243,6 @@ ContingencyTablesInternal <- function(jaspResults, dataset, options, ...) {
 .crossTabOdds <- function(jaspResults, dataset, options, analyses, ready){
   if (!options$oddsRatio)
     return ()
-
   for (i in 1:nrow(analyses)) {
     analysis <- analyses[i,]
     analysisContainer <- jaspResults[[.crossTabCreateContainerName(analysis)]]
@@ -461,7 +460,6 @@ ContingencyTablesInternal <- function(jaspResults, dataset, options, ...) {
                             table$addColumnInfo(name = paste0("low[",   fold, "]"),   title = gettext("Lower"),          type = "number", overtitle = ci.label, format = "dp:3")
                             table$addColumnInfo(name = paste0("up[",    fold, "]"),   title = gettext("Upper"),          type = "number", overtitle = ci.label, format = "dp:3")
                             table$addColumnInfo(name = paste0("p[",     fold, "]"),   title = gettext("p"),              type = "pvalue")
-
 }
 
 .crossTabNominalAddColInfo <- function(table, fold){
@@ -1162,7 +1160,7 @@ ContingencyTablesInternal <- function(jaspResults, dataset, options, ...) {
       group <- NULL
 
     row <- list()
-    row[["type[oddsRatio]"]] <- "Odds ratio"
+    row[["type[oddsRatio]"]] <- analysisContainer[["crossTabLogOdds"]]$title
     if (ready) {
       if ( ! identical(dim(counts.matrix),as.integer(c(2,2)))) {
         row[["value[oddsRatio]"]] <- NaN


### PR DESCRIPTION
PR for issue #2681

*Problem:*
The row label for the calculated (log) odds ratio was a constant string "Odds ratio", and didn't reflect whether odds ratio or log odds ratio was calculated.

*Solution:*
- The label value in the row was made to reflect the title chosen for the analysis container itself, which is Log Odds Ratio when it is chosen in options
- The label is now dependent on what is set as the title variable in function .crossTabOdds()
- Relating back to issue #2681, should the column label for the estimates be renamed "Point estimate", or kept the same?

<img width="1598" height="816" alt="Screenshot From 2025-09-03 22-41-58" src="https://github.com/user-attachments/assets/8a2068d4-6d67-4fc7-9cf9-60d11776076f" />


